### PR TITLE
Only update actual codecov coverage report (for badge) on merge to main.

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -40,6 +40,7 @@ jobs:
         shell: Rscript {0}
 
       - uses: codecov/codecov-action@v4
+        if: ${{ github.ref == 'refs/heads/main' }}
         with:
           fail_ci_if_error: ${{ github.event_name != 'pull_request' && true || false }}
           file: ./cobertura.xml


### PR DESCRIPTION
## Overview
When we're ready to release we'll need to finish codecov setup, but we don't need it before then (and in fact it's somewhat confusing to show the wrong number/report on our pkgdown site).

## Test Notes/Sample Code
We can't really test this other than by seeing that nothing fails when we merge to dev.

Notes: 

