### PR TITLE
Prevent extraneous shiny-load warning.

### DIFF
--- a/R/_disable_autoload.R
+++ b/R/_disable_autoload.R
@@ -1,0 +1,1 @@
+# Prevent shiny from throwing a warning during test-app startup.


### PR DESCRIPTION
## Overview
Prevent shiny from throwing a warning during test-app startup.

## Test Notes/Sample Code
<!--- Notes about testing or code to reproduce new functionality --->

Notes: 

