### PR TITLE
Deploy to shinyapps

### DIFF
--- a/.github/workflows/shinyapps-deploy.yaml
+++ b/.github/workflows/shinyapps-deploy.yaml
@@ -63,7 +63,7 @@ jobs:
           if (deployment_type != "prod") {
             appname <- paste(appname, deployment_type, sep = "_")
             if (nzchar(pr_number)) {
-              appname <- paste(appname, pr_number, sep = "_"
+              appname <- paste(appname, pr_number, sep = "_")
             }
           }
           rsconnect::setAccountInfo(

--- a/.github/workflows/shinyapps-deploy.yaml
+++ b/.github/workflows/shinyapps-deploy.yaml
@@ -54,20 +54,23 @@ jobs:
       - name: Install packages
         run: |
           install.packages("pak")
-          # These packages are sometimes corrupted as far as rsconnect is
-          # concerned. I suspect they're installed more directly than it can
-          # trace.
-          extras <- c(
-            "devtools",
-            "pkgdown",
-            "AsioHeaders",
-            "cpp11",
-            "progress"
+          pak::pak("sessioninfo")
+
+          # Update anything that was installed from cache, etc. rsconnect needs
+          # to know how to download the package.
+          installed_packages <- sessioninfo::package_info()
+          sources <- tolower(installed_packages$source)
+          has_other_source <- !(
+            startsWith(sources, "cran") |
+              startsWith(sources, "github") |
+              startsWith(sources, "biocon") |
+              grepl("r-universe", sources)
           )
-          remove.packages(intersect(extras, rownames(installed.packages())))
-          pak::pak(extras)
+          weird_packages <- installed_packages$package[has_other_source]
+          remove.packages(weird_packages)
           pak::pak()
           pak::pak("rsconnect")
+          pak::pak(weird_packages)
         shell: Rscript {0}
 
       - name: Push to shinyapps.io

--- a/.github/workflows/shinyapps-deploy.yaml
+++ b/.github/workflows/shinyapps-deploy.yaml
@@ -51,7 +51,16 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::devtools, any::xml2, any::rsconnect, any::AsioHeaders, any::cpp11, any::progress
+          # Cover everything it might decide it wants. rsconnect is being
+          # finicky.
+          extra-packages: |
+            any::devtools
+            any::xml2
+            any::rsconnect
+            any::AsioHeaders
+            any::cpp11
+            any::progress
+            any::tzdb
 
       - name: Push to shinyapps.io
         env:

--- a/.github/workflows/shinyapps-deploy.yaml
+++ b/.github/workflows/shinyapps-deploy.yaml
@@ -58,6 +58,8 @@ jobs:
 
       - name: Install packages
         run: |
+          install.packages("pak")
+
           # These packages are sometimes corrupted as far as rsconnect is
           # concerned. I suspect they're installed more directly than it can
           # trace.

--- a/.github/workflows/shinyapps-deploy.yaml
+++ b/.github/workflows/shinyapps-deploy.yaml
@@ -83,9 +83,9 @@ jobs:
           pr_number <- Sys.getenv("PR_NUMBER")
 
           if (deployment_type != "prod") {
-            appname <- paste(appname, deployment_type, sep = "_")
+            appname <- paste(appname, deployment_type, sep = "-")
             if (nzchar(pr_number)) {
-              appname <- paste(appname, pr_number, sep = "_")
+              appname <- paste(appname, pr_number, sep = "-")
             }
           }
           rsconnect::setAccountInfo(

--- a/.github/workflows/shinyapps-deploy.yaml
+++ b/.github/workflows/shinyapps-deploy.yaml
@@ -49,7 +49,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::rsconnect
+          extra-packages: any::devtools, any::xml2, any::rsconnect
 
       - name: Push to shinyapps.io
         env:

--- a/.github/workflows/shinyapps-deploy.yaml
+++ b/.github/workflows/shinyapps-deploy.yaml
@@ -46,6 +46,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/.github/workflows/shinyapps-deploy.yaml
+++ b/.github/workflows/shinyapps-deploy.yaml
@@ -51,9 +51,12 @@ jobs:
         with:
           use-public-rspm: true
 
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::rsconnect
+
       - name: Install packages
         run: |
-          install.packages("pak")
           # These packages are sometimes corrupted as far as rsconnect is
           # concerned. I suspect they're installed more directly than it can
           # trace.

--- a/.github/workflows/shinyapps-deploy.yaml
+++ b/.github/workflows/shinyapps-deploy.yaml
@@ -68,9 +68,10 @@ jobs:
           )
           weird_packages <- installed_packages$package[has_other_source]
           remove.packages(weird_packages)
+          pak::pak(weird_packages)
+
           pak::pak()
           pak::pak("rsconnect")
-          pak::pak(weird_packages)
         shell: Rscript {0}
 
       - name: Push to shinyapps.io

--- a/.github/workflows/shinyapps-deploy.yaml
+++ b/.github/workflows/shinyapps-deploy.yaml
@@ -53,8 +53,8 @@ jobs:
 
       - name: Push to shinyapps.io
         env:
-          SHINYAPPS_TOKEN: ${{ secrets.SHINYAPPS_TOKEN }}
-          SHINYAPPS_SECRET: ${{ secrets.SHINYAPPS_SECRET }}
+          SHINYAPPSIO_TOKEN: ${{ secrets.SHINYAPPSIO_TOKEN }}
+          SHINYAPPSIO_SECRET: ${{ secrets.SHINYAPPSIO_SECRET }}
         run: |
           appname <- Sys.getenv("REPO_NAME")
           deployment_type <- Sys.getenv("DEPLOYMENT_TYPE")
@@ -68,8 +68,8 @@ jobs:
           }
           rsconnect::setAccountInfo(
             name = "openrbqm",
-            token = Sys.getenv("SHINYAPPS_TOKEN"),
-            secret = Sys.getenv("SHINYAPPS_SECRET")
+            token = Sys.getenv("SHINYAPPSIO_TOKEN"),
+            secret = Sys.getenv("SHINYAPPSIO_SECRET")
           )
           rsconnect::deployApp(
             appName = appname,

--- a/.github/workflows/shinyapps-deploy.yaml
+++ b/.github/workflows/shinyapps-deploy.yaml
@@ -51,7 +51,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::devtools, any::xml2, any::rsconnect
+          extra-packages: any::devtools, any::xml2, any::rsconnect, any::AsioHeaders, any::cpp11, any::progress
 
       - name: Push to shinyapps.io
         env:

--- a/.github/workflows/shinyapps-deploy.yaml
+++ b/.github/workflows/shinyapps-deploy.yaml
@@ -67,7 +67,7 @@ jobs:
             }
           }
           rsconnect::setAccountInfo(
-            name = "openrbqm"",
+            name = "openrbqm",
             token = Sys.getenv("SHINYAPPS_TOKEN"),
             secret = Sys.getenv("SHINYAPPS_SECRET")
           )

--- a/.github/workflows/shinyapps-deploy.yaml
+++ b/.github/workflows/shinyapps-deploy.yaml
@@ -51,9 +51,21 @@ jobs:
         with:
           use-public-rspm: true
 
-      - name: Install packages mostly manually
+      - name: Install packages
         run: |
           install.packages("pak")
+          # These packages are sometimes corrupted as far as rsconnect is
+          # concerned. I suspect they're installed more directly than it can
+          # trace.
+          extras <- c(
+            "devtools",
+            "pkgdown",
+            "AsioHeaders",
+            "cpp11",
+            "progress"
+          )
+          remove.packages(intersect(extras, rownames(installed.packages())))
+          pak::pak(extras)
           pak::pak()
           pak::pak("rsconnect")
         shell: Rscript {0}

--- a/.github/workflows/shinyapps-deploy.yaml
+++ b/.github/workflows/shinyapps-deploy.yaml
@@ -1,0 +1,78 @@
+name: Deploy Repo to shinyapps.io
+on:
+  push:
+    branches: [dev, main]
+  pull_request:
+    branches: [dev, main]
+    paths-ignore:
+      - 'README.md'
+  workflow_dispatch:
+    inputs:
+      target-deployment:
+        description: 'Select the target shinyapps deployment type'
+        required: true
+        default: 'dev'
+        type: choice
+        options:
+          - dev
+          - prod
+          - pr
+
+jobs:
+  shinyapps-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract repository name
+        run: echo "REPO_NAME=${GITHUB_REPOSITORY##*/}" >> $GITHUB_ENV
+
+      - name: Set DEPLOYMENT_TYPE for workflow_dispatch
+        if: github.event_name == 'workflow_dispatch'
+        run: echo "DEPLOYMENT_TYPE=${{ github.event.inputs.target-deployment }}" >> $GITHUB_ENV
+
+      - name: Set DEPLOYMENT_TYPE for pull requests
+        if: github.event_name == 'pull_request'
+        run: |
+          echo "DEPLOYMENT_TYPE=pr" >> $GITHUB_ENV
+          echo "PR_NUMBER=${{ github.event.pull_request.number }}" >> $GITHUB_ENV
+
+      - name: Set DEPLOYMENT_TYPE for pushes to dev
+        if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
+        run: echo "DEPLOYMENT_TYPE=dev" >> $GITHUB_ENV
+
+      - name: Set DEPLOYMENT_TYPE for pushes to main
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: echo "DEPLOYMENT_TYPE=prod" >> $GITHUB_ENV
+
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-r@v2
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::rsconnect
+
+      - name: Push to shinyapps.io
+        env:
+          SHINYAPPS_TOKEN: ${{ secrets.SHINYAPPS_TOKEN }}
+          SHINYAPPS_SECRET: ${{ secrets.SHINYAPPS_SECRET }}
+        run: |
+          appname <- Sys.getenv("REPO_NAME")
+          deployment_type <- Sys.getenv("DEPLOYMENT_TYPE")
+          pr_number <- Sys.getenv("PR_NUMBER")
+
+          if (deployment_type != "prod") {
+            appname <- paste(appname, deployment_type, sep = "_")
+            if (nzchar(pr_number)) {
+              appname <- paste(appname, pr_number, sep = "_"
+            }
+          }
+          rsconnect::setAccountInfo(
+            name = "openrbqm"",
+            token = Sys.getenv("SHINYAPPS_TOKEN"),
+            secret = Sys.getenv("SHINYAPPS_SECRET")
+          )
+          rsconnect::deployApp(
+            appName = appname,
+            forceUpdate = TRUE
+          )
+        shell: Rscript {0}

--- a/.github/workflows/shinyapps-deploy.yaml
+++ b/.github/workflows/shinyapps-deploy.yaml
@@ -2,6 +2,8 @@ name: Deploy Repo to shinyapps.io
 on:
   push:
     branches: [dev, main]
+    paths-ignore:
+      - 'README.md'
   pull_request:
     branches: [dev, main]
     paths-ignore:
@@ -21,6 +23,9 @@ on:
 jobs:
   shinyapps-deploy:
     runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+      cancel-in-progress: true
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -50,10 +55,6 @@ jobs:
       - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
-
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: any::rsconnect
 
       - name: Install packages
         run: |

--- a/.github/workflows/shinyapps-deploy.yaml
+++ b/.github/workflows/shinyapps-deploy.yaml
@@ -51,19 +51,12 @@ jobs:
         with:
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          # Cover everything it might decide it wants. rsconnect is being
-          # finicky.
-          extra-packages: |
-            any::devtools
-            any::xml2
-            any::rsconnect
-            any::AsioHeaders
-            any::cpp11
-            any::progress
-            any::tzdb
-            any::sessioninfo
+      - name: Install packages mostly manually
+        run: |
+          install.packages("pak")
+          pak::pak()
+          pak::pak("rsconnect")
+        shell: Rscript {0}
 
       - name: Push to shinyapps.io
         env:

--- a/.github/workflows/shinyapps-deploy.yaml
+++ b/.github/workflows/shinyapps-deploy.yaml
@@ -54,22 +54,18 @@ jobs:
       - name: Install packages
         run: |
           install.packages("pak")
-          pak::pak("sessioninfo")
-
-          # Update anything that was installed from cache, etc. rsconnect needs
-          # to know how to download the package.
-          installed_packages <- sessioninfo::package_info()
-          sources <- tolower(installed_packages$source)
-          has_other_source <- !(
-            startsWith(sources, "cran") |
-              startsWith(sources, "github") |
-              startsWith(sources, "biocon") |
-              grepl("r-universe", sources)
+          # These packages are sometimes corrupted as far as rsconnect is
+          # concerned. I suspect they're installed more directly than it can
+          # trace.
+          extras <- c(
+            "devtools",
+            "pkgdown",
+            "AsioHeaders",
+            "cpp11",
+            "progress"
           )
-          weird_packages <- installed_packages$package[has_other_source]
-          remove.packages(weird_packages)
-          pak::pak(weird_packages)
-
+          remove.packages(intersect(extras, rownames(installed.packages())))
+          pak::pak(extras)
           pak::pak()
           pak::pak("rsconnect")
         shell: Rscript {0}

--- a/.github/workflows/shinyapps-deploy.yaml
+++ b/.github/workflows/shinyapps-deploy.yaml
@@ -21,6 +21,8 @@ on:
 jobs:
   shinyapps-deploy:
     runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Extract repository name
         run: echo "REPO_NAME=${GITHUB_REPOSITORY##*/}" >> $GITHUB_ENV
@@ -61,6 +63,7 @@ jobs:
             any::cpp11
             any::progress
             any::tzdb
+            any::sessioninfo
 
       - name: Push to shinyapps.io
         env:

--- a/.github/workflows/shinyapps-terminate.yaml
+++ b/.github/workflows/shinyapps-terminate.yaml
@@ -36,14 +36,19 @@ jobs:
             token = Sys.getenv("SHINYAPPSIO_TOKEN"),
             secret = Sys.getenv("SHINYAPPSIO_SECRET")
           )
+          app_error <- function(e) {
+            if (grepl("^No application named", e$message)) {
+              message(e$message)
+            } else {
+              signalCondition(e)
+            }
+          }
           tryCatch(
             rsconnect::terminateApp(appName = appname),
-            error = function(e) {
-              if (grepl("^No application named", e$message)) {
-                message(e$message)
-              } else {
-                signalCondition(e)
-              }
-            }
+            error = app_error
+          )
+          tryCatch(
+            rsconnect::purgeApp(appName = appname),
+            error = app_error
           )
         shell: Rscript {0}

--- a/.github/workflows/shinyapps-terminate.yaml
+++ b/.github/workflows/shinyapps-terminate.yaml
@@ -29,7 +29,7 @@ jobs:
             Sys.getenv("REPO_NAME"),
             "pr",
             Sys.getenv("PR_NUMBER"),
-            sep = "_"
+            sep = "-"
           )
           rsconnect::setAccountInfo(
             name = "openrbqm",

--- a/.github/workflows/shinyapps-terminate.yaml
+++ b/.github/workflows/shinyapps-terminate.yaml
@@ -1,0 +1,44 @@
+name: Terminate shinyapps.io App on PR Close
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  terminate-shinyapp:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set PR_NUMBER and REPO_NAME
+        run: |
+          echo "PR_NUMBER=${{ github.event.pull_request.number }}" >> $GITHUB_ENV
+          echo "REPO_NAME=${GITHUB_REPOSITORY##*/}" >> $GITHUB_ENV
+
+      - uses: r-lib/actions/setup-r@v2
+
+      - name: Terminate Shiny App
+        env:
+          SHINYAPPS_TOKEN: ${{ secrets.SHINYAPPS_TOKEN }}
+          SHINYAPPS_SECRET: ${{ secrets.SHINYAPPS_SECRET }}
+        run: |
+          install.packages("rsconnect")
+          appname <- paste(
+            Sys.getenv("REPO_NAME"),
+            "pr",
+            Sys.getenv("PR_NUMBER"),
+            sep = "_"
+          )
+          rsconnect::setAccountInfo(
+            name = "openrbqm",
+            token = Sys.getenv("SHINYAPPS_TOKEN"),
+            secret = Sys.getenv("SHINYAPPS_SECRET")
+          )
+          tryCatch(
+            rsconnect::terminateApp(appName = appname),
+            error = function(e) {
+              if (grepl("^No application named", e$message)) {
+                message(e$message)
+              } else {
+                signalCondition(e)
+              }
+            }
+          )
+        shell: Rscript {0}

--- a/.github/workflows/shinyapps-terminate.yaml
+++ b/.github/workflows/shinyapps-terminate.yaml
@@ -6,6 +6,8 @@ on:
 jobs:
   terminate-shinyapp:
     runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Set PR_NUMBER and REPO_NAME
         run: |

--- a/.github/workflows/shinyapps-terminate.yaml
+++ b/.github/workflows/shinyapps-terminate.yaml
@@ -6,6 +6,9 @@ on:
 jobs:
   terminate-shinyapp:
     runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+      cancel-in-progress: true
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/.github/workflows/shinyapps-terminate.yaml
+++ b/.github/workflows/shinyapps-terminate.yaml
@@ -13,13 +13,16 @@ jobs:
           echo "REPO_NAME=${GITHUB_REPOSITORY##*/}" >> $GITHUB_ENV
 
       - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
 
       - name: Terminate Shiny App
         env:
           SHINYAPPSIO_TOKEN: ${{ secrets.SHINYAPPSIO_TOKEN }}
           SHINYAPPSIO_SECRET: ${{ secrets.SHINYAPPSIO_SECRET }}
         run: |
-          install.packages("rsconnect")
+          install.packages("pak")
+          pak::pak("rsconnect")
           appname <- paste(
             Sys.getenv("REPO_NAME"),
             "pr",

--- a/.github/workflows/shinyapps-terminate.yaml
+++ b/.github/workflows/shinyapps-terminate.yaml
@@ -16,8 +16,8 @@ jobs:
 
       - name: Terminate Shiny App
         env:
-          SHINYAPPS_TOKEN: ${{ secrets.SHINYAPPS_TOKEN }}
-          SHINYAPPS_SECRET: ${{ secrets.SHINYAPPS_SECRET }}
+          SHINYAPPSIO_TOKEN: ${{ secrets.SHINYAPPSIO_TOKEN }}
+          SHINYAPPSIO_SECRET: ${{ secrets.SHINYAPPSIO_SECRET }}
         run: |
           install.packages("rsconnect")
           appname <- paste(
@@ -28,8 +28,8 @@ jobs:
           )
           rsconnect::setAccountInfo(
             name = "openrbqm",
-            token = Sys.getenv("SHINYAPPS_TOKEN"),
-            secret = Sys.getenv("SHINYAPPS_SECRET")
+            token = Sys.getenv("SHINYAPPSIO_TOKEN"),
+            secret = Sys.getenv("SHINYAPPSIO_SECRET")
           )
           tryCatch(
             rsconnect::terminateApp(appName = appname),


### PR DESCRIPTION
## Overview

- When a PR is created, deploy an app for this repo to https://openrbqm.shinyapps.io/gsmApp_pr_XXXX (where XXXX is the PR number).
- When a PR is closed, terminate the associated app at shinyapps.io.
- When something is pushed into `dev` (via PR or directly), deploy an app for this repo to https://openrbqm.shinyapps.io/gsmApp_dev
- When something is pushed into `main (via PR or directly), deploy an app for this repo to https://openrbqm.shinyapps.io/gsmApp

These workflows should (once confirmed) be usable for any Shiny-App-producing repo within the [OpenRBQM](https://openrbqm.github.io/) project. Note: The shinyapps.io account name is hard-coded to "openrbqm", but that should be the only thing that has to be changed to use this elsewhere (along with setting secrets for `SHINYAPPS_TOKEN` and `SHINYAPPS_SECRET`). Theoretically that could be extracted from the repo spec when the github org name matches the shinyapps.io account name.

Closes #82.

## Test Notes/Sample Code
<!--- Notes about testing or code to reproduce new functionality --->

Notes: 

