### PR TITLE
Smarter Metric Details

### DIFF
--- a/R/mod_metric_details_server.R
+++ b/R/mod_metric_details_server.R
@@ -12,6 +12,7 @@ mod_metric_details_server <- function(
   rctv_strSite,
   rctv_strMetricID) {
   shiny::moduleServer(id, function(input, output, session) {
+    # Shared reactives ----
     rctv_dfResults_byMetricID <- reactive({
       filter_byMetricID(dfResults, rctv_strMetricID())
     })
@@ -28,57 +29,77 @@ mod_metric_details_server <- function(
       filter_byMetricID(dfBounds, rctv_strMetricID())
     })
 
-    output$scatter_plot <- gsm::renderWidget_ScatterPlot({
-      gsm::Widget_ScatterPlot(
-        rctv_dfResults_byMetricID(),
-        lMetric = rctv_lMetric(),
-        dfGroups = dfGroups,
-        dfBounds = rctv_dfBounds_byMetricID(),
-        bAddGroupSelect = FALSE,
-        strShinyGroupSelectID = "site"
+    # Outputs ----
+    observeEvent(input$selected_tab, {
+      switch(input$selected_tab,
+        "Scatter Plot" = {
+          output$scatter_plot <- gsm::renderWidget_ScatterPlot({
+            gsm::Widget_ScatterPlot(
+              rctv_dfResults_byMetricID(),
+              lMetric = rctv_lMetric(),
+              dfGroups = dfGroups,
+              dfBounds = rctv_dfBounds_byMetricID(),
+              bAddGroupSelect = FALSE,
+              strShinyGroupSelectID = "site"
+            )
+          })
+          outputOptions(output, "scatter_plot", suspendWhenHidden = FALSE)
+        },
+        "Bar Chart (KRI Value)" = {
+          output$bar_chart_metric <- gsm::renderWidget_BarChart({
+            gsm::Widget_BarChart(
+              rctv_dfResults_byMetricID(),
+              lMetric = rctv_lMetric(),
+              dfGroups = dfGroups,
+              strOutcome = "Metric",
+              bAddGroupSelect = FALSE,
+              strShinyGroupSelectID = "site"
+            )
+          })
+          outputOptions(output, "bar_chart_metric", suspendWhenHidden = FALSE)
+        },
+        "Bar Chart (KRI Score)" = {
+          output$bar_chart_score <- gsm::renderWidget_BarChart({
+            gsm::Widget_BarChart(
+              rctv_dfResults_byMetricID(),
+              lMetric = rctv_lMetric(),
+              dfGroups = dfGroups,
+              strOutcome = "Score",
+              bAddGroupSelect = FALSE,
+              strShinyGroupSelectID = "site"
+            )
+          })
+          outputOptions(output, "bar_chart_score", suspendWhenHidden = FALSE)
+        },
+        "Time Series" = {
+          output$time_series <- gsm::renderWidget_TimeSeries({
+            gsm::Widget_TimeSeries(
+              rctv_dfResults_byMetricID(),
+              lMetric = rctv_lMetric(),
+              dfGroups = dfGroups,
+              strOutcome = "Score",
+              bAddGroupSelect = FALSE,
+              strShinyGroupSelectID = "site"
+            )
+          })
+          outputOptions(output, "time_series", suspendWhenHidden = FALSE)
+        },
+        "Analysis Output" = {
+          output$results <- renderUI({
+            gsm::Report_MetricTable(
+              rctv_dfResults_byMetricID() %>%
+                filter_byGroupID(rctv_strSite()) %>%
+                dplyr::select(
+                  -dplyr::all_of(c("GroupLevel", "StudyID", "SnapshotDate"))
+                ),
+              dfGroups,
+              strGroupLevel = "Site"
+            ) %>%
+              HTML()
+          })
+          outputOptions(output, "results", suspendWhenHidden = FALSE)
+        }
       )
-    })
-    output$bar_chart_metric <- gsm::renderWidget_BarChart({
-      gsm::Widget_BarChart(
-        rctv_dfResults_byMetricID(),
-        lMetric = rctv_lMetric(),
-        dfGroups = dfGroups,
-        strOutcome = "Metric",
-        bAddGroupSelect = FALSE,
-        strShinyGroupSelectID = "site"
-      )
-    })
-    output$bar_chart_score <- gsm::renderWidget_BarChart({
-      gsm::Widget_BarChart(
-        rctv_dfResults_byMetricID(),
-        lMetric = rctv_lMetric(),
-        dfGroups = dfGroups,
-        strOutcome = "Score",
-        bAddGroupSelect = FALSE,
-        strShinyGroupSelectID = "site"
-      )
-    })
-    output$time_series <- gsm::renderWidget_TimeSeries({
-      gsm::Widget_TimeSeries(
-        rctv_dfResults_byMetricID(),
-        lMetric = rctv_lMetric(),
-        dfGroups = dfGroups,
-        strOutcome = "Score",
-        bAddGroupSelect = FALSE,
-        strShinyGroupSelectID = "site"
-      )
-    })
-    output$results <- renderUI({
-      gsm::Report_MetricTable(
-        rctv_dfResults_byMetricID() %>%
-          filter_byGroupID(rctv_strSite()) %>%
-          dplyr::select(
-            -dplyr::all_of(c("GroupLevel", "StudyID", "SnapshotDate"))
-          ),
-        dfGroups,
-        strGroupLevel = "Site"
-      ) %>%
-        HTML()
     })
   })
 }

--- a/R/server.R
+++ b/R/server.R
@@ -28,22 +28,21 @@ server <- function(
 
   ## Cross-communication ----
   sync_site_input(reactive(input$site))
+  # sync_site_input(reactive(input$scatter_site))
   # observe_metric_select(snapshot, reactives$metric)
 
   ## Hide/show ----
-  observe({
+  observeEvent(input$primary_nav_bar, {
     switch(input$primary_nav_bar,
       "Study Overview" = {
         shinyjs::hide("metric")
         shinyjs::hide("site")
         shinyjs::hide("participant")
-        # updateSelectInput(session, "site", selected = "None")
       },
       "Metric Details" = {
         shinyjs::show("metric")
         shinyjs::show("site")
         shinyjs::hide("participant")
-        # updateSelectizeInput(session, "participant", selected = "None")
       },
       "Participant Details" = {
         shinyjs::show("metric")
@@ -52,6 +51,7 @@ server <- function(
       }
     )
   })
+
   ## Reset ----
   observeEvent(input$reset, {
     initialize_metric_select(dfMetrics, session)
@@ -59,50 +59,41 @@ server <- function(
     updateSelectizeInput(session, "participant", selected = "None")
   })
 
+  # Tab Contents ----
 
-  # Study Overview ----
-  # add_metric_observer(snapshot, reactives$metric)
-  mod_study_overview_server("study_overview",
+  ## Study Overview ----
+  mod_study_overview_server(
+    "study_overview",
     dfResults = dfResults,
     dfGroups = dfGroups,
     dfMetrics = dfMetrics
   )
-
-  mod_scatter_server("scatter",
+  mod_scatter_server(
+    "scatter",
     dfResults = dfResults,
     dfMetrics = dfMetrics,
     dfGroups = dfGroups,
     dfBounds = dfBounds
   )
 
-  # Metric Details ----
-  # observe_metric_select(snapshot, reactives$metric)
-
-  mod_metric_details_server(
-    "metric_details",
-    dfResults = dfResults,
-    dfMetrics = dfMetrics,
-    dfGroups = dfGroups,
-    dfBounds = dfBounds,
-    rctv_strSite = reactive(input$site),
-    rctv_strMetricID = reactive(input$metric)
+  ## Metric Details ----
+  ##
+  ## Don't render until it loads. We should be able to fix this later once
+  ## nested-modules are implemented cleanly.
+  observeEvent(
+    input$primary_nav_bar == "Metric Details",
+    {
+      mod_metric_details_server(
+        "metric_details",
+        dfResults = dfResults,
+        dfMetrics = dfMetrics,
+        dfGroups = dfGroups,
+        dfBounds = dfBounds,
+        rctv_strSite = reactive(input$site),
+        rctv_strMetricID = reactive(input$metric)
+      )
+    },
+    ignoreInit = TRUE,
+    once = TRUE
   )
-
-  # # Site ----
-  #
-  # site_details_server(
-  #     'site_details',
-  #     snapshot,
-  #     reactives$site,
-  #     reactives$metric
-  # )
-  #
-  # # Participant Details ----
-  # initialize_participant_select(input, output, session, snapshot)
-  # observe_participant_select(reactives$participant)
-  # participant_details_server(
-  #     'participant_details',
-  #     snapshot,
-  #     reactives$participant
-  # )
 }


### PR DESCRIPTION
## Overview
Only load Metric Details tabs when they're viewed, but make them persistent (in the background) afterwards. That way the javascript can continue to communicate properly and the modules can update one another.

Closes #164.

## Test Notes/Sample Code
<!--- Notes about testing or code to reproduce new functionality --->

Notes: 

